### PR TITLE
Removed redundant "at" word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## [1.3.1] - ????-??-??
+
+Removed `at` word from result of `Awesomite\StackTrace\StackTrace::__toString` whenever step does not contain
+reference to called function, e.g.: `#0 (...)/file.php:13` instead of `#0 at (...)file.php:14`.
+
 ## [1.3.0] - 2018-09-28
 
-* Added optional parameter `$maxSerializableStringLen` to [`Awesomite\StackTrace\StackTraceFactory::__construct`](./src/StackTraceFactory.php)
+Added optional parameter `$maxSerializableStringLen` to [`Awesomite\StackTrace\StackTraceFactory::__construct`](./src/StackTraceFactory.php).
 
 ## [1.2.0] - 2018-09-21
 
@@ -37,6 +42,7 @@ in [`Value::dumpAsString()`](./src/Arguments/Values/Value.php).
 
 This version contains the same source code as [0.12.0].
 
+[1.3.1]: https://github.com/awesomite/stack-trace/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/awesomite/stack-trace/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/awesomite/stack-trace/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/awesomite/stack-trace/compare/v1.0.2...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.3.1] - ????-??-??
+## [1.3.1] - 2018-10-11
 
 Removed `at` word from result of `Awesomite\StackTrace\StackTrace::__toString` whenever step does not contain
 reference to called function, e.g.: `#0 (...)/file.php:14` instead of `#0 at (...)file.php:14`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.3.1] - ????-??-??
 
 Removed `at` word from result of `Awesomite\StackTrace\StackTrace::__toString` whenever step does not contain
-reference to called function, e.g.: `#0 (...)/file.php:13` instead of `#0 at (...)file.php:14`.
+reference to called function, e.g.: `#0 (...)/file.php:14` instead of `#0 at (...)file.php:14`.
 
 ## [1.3.0] - 2018-09-28
 

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,8 +17,6 @@ namespace Awesomite\StackTrace;
 final class Constants
 {
     const KEY_FILE_OBJECT    = '__awesomite_file_object';
-
     const KEY_ARGS_CONVERTED = '__awesomite_args_converted';
-
     const MAX_LINE_THRESHOLD = 20;
 }

--- a/src/StackTrace.php
+++ b/src/StackTrace.php
@@ -27,7 +27,7 @@ use Composer\Semver\Semver;
  */
 final class StackTrace implements StackTraceInterface
 {
-    const VERSION             = '1.3.0';
+    const VERSION             = '1.3.1';
     const CONSTRAINTS_VERSION = '^1.0.0';
 
     private $arrayStackTrace;
@@ -137,10 +137,13 @@ final class StackTrace implements StackTraceInterface
             $line = '#' . $stepNumber;
             if ($step->hasCalledFunction()) {
                 $line .= ' ' . $step->getCalledFunction()->getName() . '()';
+                if ($step->hasPlaceInCode()) {
+                    $line .= ' at';
+                }
             }
             if ($step->hasPlaceInCode()) {
                 $placeInCode = $step->getPlaceInCode();
-                $line .= ' at ' . $placeInCode->getFileName() . ':' . $placeInCode->getLineNumber();
+                $line .= ' ' . $placeInCode->getFileName() . ':' . $placeInCode->getLineNumber();
             }
 
             $result[] = $line;

--- a/tests/StackTraceFactoryTest.php
+++ b/tests/StackTraceFactoryTest.php
@@ -170,7 +170,7 @@ final class StackTraceFactoryTest extends BaseTestCase
         }
 
         $eval
-            = <<<EVAL
+            = <<<'EVAL'
 if (!function_exists('awesomite_test_function')) {
     function awesomite_test_function () {
         throw new \LogicException('Test exception 2');

--- a/tests/StackTraceFactoryTest.php
+++ b/tests/StackTraceFactoryTest.php
@@ -180,7 +180,7 @@ EVAL;
         eval($eval);
 
         try {
-            awesomite_test_function();
+            \awesomite_test_function();
         } catch (\LogicException $exception) {
             $result[] = array(
                 $factory->createByThrowable($exception, 2),

--- a/tests/StackTraceTest.php
+++ b/tests/StackTraceTest.php
@@ -118,7 +118,7 @@ final class StackTraceTest extends BaseTestCase
                     array('file' => __FILE__, 'line' => 15, 'function' => 'run', 'type' => '->', 'class' => 'Awesomite\MyApp'),
                     array('file' => __FILE__, 'line' => 23, 'function' => 'handleHttp', 'type' => '->', 'class' => 'Awesomite\MyApp\Http\Handler'),
                 ),
-                <<<OUTPUT
+                <<<'OUTPUT'
 #0 Awesomite\MyApp->run() at %file%:15
 #1 Awesomite\MyApp\Http\Handler->handleHttp() at %file%:23
 OUTPUT
@@ -128,7 +128,7 @@ OUTPUT
                     array('file' => __FILE__ . '.test', 'line' => 15, 'function' => 'run', 'type' => '->', 'class' => 'Awesomite\MyApp'),
                     array('file' => __FILE__ . '.test', 'line' => 23, 'function' => 'handleHttp', 'type' => '->', 'class' => 'Awesomite\MyApp\Http\Handler'),
                 ),
-                <<<OUTPUT
+                <<<'OUTPUT'
 #0 Awesomite\MyApp->run()
 #1 Awesomite\MyApp\Http\Handler->handleHttp()
 OUTPUT

--- a/tests/StackTraceTest.php
+++ b/tests/StackTraceTest.php
@@ -125,6 +125,16 @@ OUTPUT
             ),
             array(
                 array(
+                    array('file' => __FILE__ . '.test', 'line' => 15, 'function' => 'run', 'type' => '->', 'class' => 'Awesomite\MyApp'),
+                    array('file' => __FILE__ . '.test', 'line' => 23, 'function' => 'handleHttp', 'type' => '->', 'class' => 'Awesomite\MyApp\Http\Handler'),
+                ),
+                <<<OUTPUT
+#0 Awesomite\MyApp->run()
+#1 Awesomite\MyApp\Http\Handler->handleHttp()
+OUTPUT
+            ),
+            array(
+                array(
                     array('file' => __FILE__, 'line' => 17),
                 ),
                 '#0 %file%:17',

--- a/tests/StackTraceTest.php
+++ b/tests/StackTraceTest.php
@@ -95,18 +95,47 @@ final class StackTraceTest extends BaseTestCase
         $this->assertSame(32, \mb_strlen($stackTraceA->getId()));
     }
 
-    public function testToString()
+    /**
+     * @dataProvider providerToString
+     *
+     * @param array  $rawStackTrace
+     * @param string $expected
+     */
+    public function testToString(array $rawStackTrace, $expected)
     {
-        $factory = new StackTraceFactory();
-        $stackTrace = $factory->create();
-        $string = (string)$stackTrace;
-        $shouldContains = array(
-            __FUNCTION__,
-            __CLASS__,
+        $stackTrace = new StackTrace($rawStackTrace, new LightVarDumper(), null);
+        $expected = \str_replace('%file%', __FILE__, $expected);
+        $result = (string)$stackTrace;
+        $this->assertInternalType('string', $result);
+        $this->assertSame($expected, $result);
+    }
+
+    public function providerToString()
+    {
+        return array(
+            array(
+                array(
+                    array('file' => __FILE__, 'line' => 15, 'function' => 'run', 'type' => '->', 'class' => 'Awesomite\MyApp'),
+                    array('file' => __FILE__, 'line' => 23, 'function' => 'handleHttp', 'type' => '->', 'class' => 'Awesomite\MyApp\Http\Handler'),
+                ),
+                <<<OUTPUT
+#0 Awesomite\MyApp->run() at %file%:15
+#1 Awesomite\MyApp\Http\Handler->handleHttp() at %file%:23
+OUTPUT
+            ),
+            array(
+                array(
+                    array('file' => __FILE__, 'line' => 17),
+                ),
+                '#0 %file%:17',
+            ),
+            array(
+                array(
+                    array('function' => 'eval'),
+                ),
+                '#0 eval()',
+            ),
         );
-        foreach ($shouldContains as $expectedPart) {
-            $this->assertContains($expectedPart, $string);
-        }
     }
 
     /**


### PR DESCRIPTION
from `Awesomite\StackTrace\StackTrace::__toString` whenever step does not contain
reference to called function, e.g.: `#0 (...)/file.php:13` instead of `#0 at (...)file.php:14`.